### PR TITLE
Removed unicode quotes

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -70,7 +70,7 @@ runs:
           EXTRA_ARGS="${EXTRA_ARGS} --secretsColumns ${secret_column}"
         done
 
-        if [[ "$REUSABLE" == “true” ]]; then
+        if [[ "$REUSABLE" == "true" ]]; then
           EXTRA_ARGS="${EXTRA_ARGS} --reusable"
         fi
 


### PR DESCRIPTION
You had some unicode quotes in the action that was breaking the `reusable` var :)